### PR TITLE
Namespace conn.assigns.action to avoid conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Checks whether or not the ```current_user``` can perform the given action on the
 
 For Phoenix applications, Canary determines the action automatically.
 
-For non-Phoenix applications, or to override the action provided by Phoenix, simply ensure that ```conn.assigns.action``` contains an atom specifying the action.
+For non-Phoenix applications, or to override the action provided by Phoenix, simply ensure that ```conn.assigns.canary_action``` contains an atom specifying the action.
 
 In order to authorize resources, you must specify permissions by implementing the [Canada.Can protocol](https://github.com/jarednorman/canada) for your ```User``` model (Canada is included as a light weight dependency).
 

--- a/lib/canary/plugs.ex
+++ b/lib/canary/plugs.ex
@@ -262,7 +262,7 @@ defmodule Canary.Plugs do
 
   defp get_action(conn) do
     conn.assigns
-    |> Map.fetch(:action)
+    |> Map.fetch(:canary_action)
     |> case do
       {:ok, action} -> action
       _             -> conn.private.phoenix_action


### PR DESCRIPTION
That is, conflict with unrelated resource assigned to .action.