### PR TITLE
Ability to specify name of resource id

### DIFF
--- a/lib/canary/plugs.ex
+++ b/lib/canary/plugs.ex
@@ -222,12 +222,7 @@ defmodule Canary.Plugs do
   defp fetch_resource(conn, opts) do
     repo = Application.get_env(:canary, :repo)
 
-    id = case opts[:id] do
-      nil ->
-        conn.params["id"]
-      resource_id ->
-        conn.params[resource_id]
-    end
+    id = get_resource_id(conn, opts)
 
     conn
     |> Map.fetch(resource_name(conn, opts))
@@ -246,6 +241,15 @@ defmodule Canary.Plugs do
             repo.get(opts[:model], id)
             |> preload_if_needed(repo, opts)
         end
+    end
+  end
+
+  defp get_resource_id(conn, opts) do
+    case opts[:id] do
+      nil ->
+        conn.params["id"]
+      resource_id ->
+        conn.params[resource_id]
     end
   end
 

--- a/lib/canary/plugs.ex
+++ b/lib/canary/plugs.ex
@@ -23,8 +23,8 @@ defmodule Canary.Plugs do
   @doc """
   Load the given resource.
 
-  Load the resource with id given by `conn.params[opt[:id]]` (`opts[:id]` defaults to "id") ecto model given
-  by opts[:model] into `conn.assigns.resource_name`.
+  Load the resource with id given by `conn.params["id"]` (or `conn.params[opts[:id]]` if `opts[:id]` is specified)
+  and ecto model given by `opts[:model]` into `conn.assigns.resource_name`.
 
   `resource_name` is either inferred from the model name or specified in the plug declaration with the `:as` key.
   To infer the `resource_name`, the most specific(right most) name in the model's

--- a/lib/canary/plugs.ex
+++ b/lib/canary/plugs.ex
@@ -23,7 +23,7 @@ defmodule Canary.Plugs do
   @doc """
   Load the given resource.
 
-  Load the resource with id given by `conn.params["id"]` (or `conn.params[opts[:id]]` if `opts[:id]` is specified)
+  Load the resource with id given by `conn.params["id"]` (or `conn.params[opts[:id_name]]` if `opts[:id_name]` is specified)
   and ecto model given by `opts[:model]` into `conn.assigns.resource_name`.
 
   `resource_name` is either inferred from the model name or specified in the plug declaration with the `:as` key.
@@ -222,30 +222,30 @@ defmodule Canary.Plugs do
   defp fetch_resource(conn, opts) do
     repo = Application.get_env(:canary, :repo)
 
-    id = get_resource_id(conn, opts)
+    id_name = get_resource_id_name(conn, opts)
 
     conn
     |> Map.fetch(resource_name(conn, opts))
     |> case do
       :error ->
-        repo.get(opts[:model], id)
+        repo.get(opts[:model], id_name)
         |> preload_if_needed(repo, opts)
       {:ok, nil} ->
-        repo.get(opts[:model], id)
+        repo.get(opts[:model], id_name)
         |> preload_if_needed(repo, opts)
       {:ok, resource} -> # if there is already a resource loaded onto the conn
         case (resource.__struct__ == opts[:model]) do
           true  ->
             resource
           false ->
-            repo.get(opts[:model], id)
+            repo.get(opts[:model], id_name)
             |> preload_if_needed(repo, opts)
         end
     end
   end
 
-  defp get_resource_id(conn, opts) do
-    case opts[:id] do
+  defp get_resource_id_name(conn, opts) do
+    case opts[:id_name] do
       nil ->
         conn.params["id"]
       resource_id ->

--- a/test/plug_test.exs
+++ b/test/plug_test.exs
@@ -103,6 +103,17 @@ defmodule PlugTest do
     assert load_resource(conn, opts) == expected
   end
 
+  test "it loads the resource correctly with opts[:id] specified" do
+    opts = [model: Post, id: "user_id"]
+
+    # when id param is correct
+    params = %{"user_id" => 1}
+    conn = conn(%Plug.Conn{private: %{phoenix_action: :show}}, :get, "/posts/1", params)
+    expected = %{conn | assigns: Map.put(conn.assigns, :post, %Post{id: 1})}
+
+    assert load_resource(conn, opts) == expected
+  end
+
   test "it authorizes the resource correctly" do
     opts = [model: Post]
 

--- a/test/plug_test.exs
+++ b/test/plug_test.exs
@@ -103,8 +103,8 @@ defmodule PlugTest do
     assert load_resource(conn, opts) == expected
   end
 
-  test "it loads the resource correctly with opts[:id] specified" do
-    opts = [model: Post, id: "user_id"]
+  test "it loads the resource correctly with opts[:id_name] specified" do
+    opts = [model: Post, id_name: "user_id"]
 
     # when id param is correct
     params = %{"user_id" => 1}


### PR DESCRIPTION
Instead of assuming resource id is named "id" this PR let's you override it and specify the name of the resource id while defaulting to "id" if none is specified.

Use it like so:

     plug :load_resource, model: User, id_name: "user_id", only: :show